### PR TITLE
feat: add new big commerce samples

### DIFF
--- a/providers/bigcommerce/2025-04/store.brand.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.brand.metafield.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "215"
+  },
+  "body": {
+    "scope": "store/brand/metafield/created",
+    "store_id": "1025646",
+    "data": {
+      "metafield_id": 16,
+      "resource_id": "38"
+    },
+    "hash": "352e4afc6dd3fc85ea26bfdf3f91852604d57528",
+    "created_at": 1561482670,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/brand/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.cart.converted.json
+++ b/providers/bigcommerce/2025-04/store.cart.converted.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "241"
+  },
+  "body": {
+    "scope": "store/cart/converted",
+    "store_id": "1025646",
+    "data": {
+      "type": "cart",
+      "id": "d30016e2-23c0-4a90-884f-2e92ac135476",
+      "orderId": 252
+    },
+    "hash": "b86db7c77d7ef8f90d6a8aefa56de32ccd776923",
+    "created_at": 1561486893,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/cart/converted"
+}

--- a/providers/bigcommerce/2025-04/store.cart.couponApplied.json
+++ b/providers/bigcommerce/2025-04/store.cart.couponApplied.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "244"
+  },
+  "body": {
+    "scope": "store/cart/couponApplied",
+    "store_id": "1025646",
+    "data": {
+      "type": "cart",
+      "id": "09346904-4175-44fd-be53-f7e598531b6c",
+      "couponId": 1
+    },
+    "hash": "4b7297d295141b660e8db5a0d99dfcdf459fe825",
+    "created_at": 1561482761,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/cart/couponApplied"
+}

--- a/providers/bigcommerce/2025-04/store.cart.created.json
+++ b/providers/bigcommerce/2025-04/store.cart.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "225"
+  },
+  "body": {
+    "scope": "store/cart/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "cart",
+      "id": "09346904-4175-44fd-be53-f7e598531b6c"
+    },
+    "hash": "352e4afc6dd3fc85ea26bfdf3f91852604d57528",
+    "created_at": 1561482670,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/cart/created"
+}

--- a/providers/bigcommerce/2025-04/store.cart.lineItem.created.json
+++ b/providers/bigcommerce/2025-04/store.cart.lineItem.created.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "292"
+  },
+  "body": {
+    "scope": "store/cart/lineItem/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "cart_line_item",
+      "id": "743bfd94-d5dd-47c5-9c19-6eec32ca6119",
+      "cartId": "b0386708-fef3-45de-9d8b-fbe3031450a4"
+    },
+    "hash": "399321a1bf1ac1331e12826fb89f264b4c8d21a6",
+    "created_at": 1561481786,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/cart/lineItem/created"
+}

--- a/providers/bigcommerce/2025-04/store.cart.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.cart.metafield.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "248"
+  },
+  "body": {
+    "scope": "store/cart/metafield/created",
+    "store_id": "1025646",
+    "data": {
+      "metafield_id": 20,
+      "resource_id": "29520ea6-2d39-4b39-836e-06ea14bf9f69"
+    },
+    "hash": "352e4afc6dd3fc85ea26bfdf3f91852604d57528",
+    "created_at": 1561482670,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/cart/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.category.created.json
+++ b/providers/bigcommerce/2025-04/store.category.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "197"
+  },
+  "body": {
+    "scope": "store/category/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "category",
+      "id": 42
+    },
+    "hash": "dc3a47c15425d2c895dba674f86fe71a8f3b6459",
+    "created_at": 1561480214,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/category/created"
+}

--- a/providers/bigcommerce/2025-04/store.category.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.category.metafield.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "218"
+  },
+  "body": {
+    "scope": "store/category/metafield/created",
+    "store_id": "1025646",
+    "data": {
+      "metafield_id": 17,
+      "resource_id": "24"
+    },
+    "hash": "dc3a47c15425d2c895dba674f86fe71a8f3b6459",
+    "created_at": 1561480214,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/category/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.*.inventory.product.stock_changed.json
+++ b/providers/bigcommerce/2025-04/store.channel.*.inventory.product.stock_changed.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "249"
+  },
+  "body": {
+    "producer": "stores/{store_hash}",
+    "hash": "996ea203c939d05ca667a515ef2f029976d6df80",
+    "created_at": 1682624640,
+    "store_id": "1234567890",
+    "scope": "store/channel/*/inventory/product/stock_changed",
+    "data": {
+      "variant_id": 127,
+      "product_id": 113,
+      "location_id": 2
+    }
+  },
+  "topic": "store/channel/*/inventory/product/stock_changed"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.cart.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.cart.created.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "217"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/cart/created",
+    "data": {
+      "cart_id": "41696c19-486f-40a8-ae2a-389d5d24e0c9"
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/cart/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.cart.lineItems.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.cart.lineItems.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "281"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/cart/lineItems/created",
+    "data": {
+      "cart_id": "41696c19-486f-40a8-ae2a-389d5d24e0c9",
+      "cart_item_id": "af133539-0d83-464d-870d-776e2672e8f4"
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/cart/lineItems/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.category.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.category.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "201"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/category/created",
+    "data": {
+      "category_id": 35,
+      "tree_id": 1
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/category/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.categoryTree.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.categoryTree.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "188"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/categoryTree/updated",
+    "data": {
+      "tree_id": 1
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/categoryTree/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.notifications.abandonedCart.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.notifications.abandonedCart.updated.json
@@ -1,0 +1,21 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "192"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/notifications/abandonedCart/updated",
+    "data": {},
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/notifications/abandonedCart/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.order.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.order.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "184"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/order/updated",
+    "data": {
+      "order_id": 127
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/order/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.page.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.page.created.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "181"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/page/created",
+    "data": {
+      "page_id": 11
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/page/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.product.assigned.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.product.assigned.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "189"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/product/assigned",
+    "data": {
+      "product_id": 127
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/product/assigned"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.script.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.script.created.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "216"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/script/created",
+    "data": {
+      "uuid": "0187cc6c-cebf-45f9-93b8-7dd0a2e09774"
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/script/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.settings.emailStatus.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.settings.emailStatus.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "223"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/settings/emailStatus/updated",
+    "data": {
+      "template_kind": "product_review_email"
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/settings/emailStatus/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.settings.route.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.settings.route.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "193"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/settings/route/updated",
+    "data": {
+      "site_id": 1000
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/settings/route/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.settings.searchContextFilters.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.settings.searchContextFilters.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "210"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/settings/searchContextFilters/updated",
+    "data": {
+      "category_id": 29
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/settings/searchContextFilters/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.settings.site.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.settings.site.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "192"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/settings/site/updated",
+    "data": {
+      "site_id": 1001
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/settings/site/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.socialMediaLinks.updated.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.socialMediaLinks.updated.json
@@ -1,0 +1,21 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "181"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/socialMediaLinks/updated",
+    "data": {},
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/socialMediaLinks/updated"
+}

--- a/providers/bigcommerce/2025-04/store.channel.1.theme.configuration.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.1.theme.configuration.created.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "397"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/1/theme/configuration/created",
+    "data": {
+      "theme_id": "e3d82ce0-9bae-0133-0de7-525400970412",
+      "variation_id": "f49489c0-8678-013a-2933-5227bc3d7181",
+      "version_id": "f4337c30-8678-013a-2933-5227bc3d7181",
+      "configuration_id": "2dc1c3f0-b2cf-013a-a341-2aac1278f99c"
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/1/theme/configuration/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "185"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1335335335,
+    "scope": "store/channel/created",
+    "data": {
+      "type": "channel",
+      "id": 2
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/created"
+}

--- a/providers/bigcommerce/2025-04/store.channel.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.channel.metafield.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "207"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/channel/metafield/created",
+    "data": {
+      "metafield_id": 21,
+      "resource_id": "1"
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/channel/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.customer.address.created.json
+++ b/providers/bigcommerce/2025-04/store.customer.address.created.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "234"
+  },
+  "body": {
+    "scope": "store/customer/address/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "customer",
+      "id": 60,
+      "address": {
+        "customer_id": 32
+      }
+    },
+    "hash": "416ca9c01779515de91824aa1cac9012ee691e7a",
+    "created_at": 1561481620,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/customer/address/created"
+}

--- a/providers/bigcommerce/2025-04/store.customer.channel.login.access.updated.json
+++ b/providers/bigcommerce/2025-04/store.customer.channel.login.access.updated.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "218"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/customer/channel/login/access/updated",
+    "data": {
+      "customer_id": 22,
+      "channel_ids": [
+        1
+      ]
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/customer/channel/login/access/updated"
+}

--- a/providers/bigcommerce/2025-04/store.customer.created.json
+++ b/providers/bigcommerce/2025-04/store.customer.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "197"
+  },
+  "body": {
+    "scope": "store/customer/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "customer",
+      "id": 32
+    },
+    "hash": "8768ab15aa86c6d73c7e4c3efbaee072110ad1d2",
+    "created_at": 1561481571,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/customer/created"
+}

--- a/providers/bigcommerce/2025-04/store.information.updated.json
+++ b/providers/bigcommerce/2025-04/store.information.updated.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "189"
+  },
+  "body": {
+    "scope": "store/information/updated",
+    "store_id": "1025646",
+    "data": {
+      "type": "store"
+    },
+    "hash": "c553845e0a5e28dc8b0ea494458692a25586a294",
+    "created_at": 1535489273,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/information/updated"
+}

--- a/providers/bigcommerce/2025-04/store.inventory.location.created.json
+++ b/providers/bigcommerce/2025-04/store.inventory.location.created.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "200"
+  },
+  "body": {
+    "producer": "stores/{store_hash}",
+    "hash": "f23133c2b4caa5a8763b678fed2e3b643348599d",
+    "created_at": 1682627509,
+    "store_id": "1234567890",
+    "scope": "store/inventory/location/created",
+    "data": {
+      "location_id": 2
+    }
+  },
+  "topic": "store/inventory/location/created"
+}

--- a/providers/bigcommerce/2025-04/store.inventory.location.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.inventory.location.metafield.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "230"
+  },
+  "body": {
+    "scope": "store/inventory/location/metafield/created",
+    "store_id": "1001197568",
+    "data": {
+      "metafield_id": 10,
+      "resource_id": "1"
+    },
+    "hash": "e0c298b8097a6a2f39d17e593a9b360f5b2fef7d",
+    "created_at": 1683303055,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/inventory/location/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.metafield.created.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "239"
+  },
+  "body": {
+    "scope": "store/metafield/created",
+    "store_id": "1001197568",
+    "data": {
+      "metafield_id": 12,
+      "resource_id": "118",
+      "resource_type": "product"
+    },
+    "hash": "60f42bd247b52f0647cbd16b1205c84260287141",
+    "created_at": 1683305167,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.metafield.updated.json
+++ b/providers/bigcommerce/2025-04/store.metafield.updated.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "238"
+  },
+  "body": {
+    "scope": "store/metafield/updated",
+    "store_id": "1001197568",
+    "data": {
+      "metafield_id": 10,
+      "resource_id": "1",
+      "resource_type": "location"
+    },
+    "hash": "e0c298b8097a6a2f39d17e593a9b360f5b2fef7d",
+    "created_at": 1683303055,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/metafield/updated"
+}

--- a/providers/bigcommerce/2025-04/store.modifier.updated.json
+++ b/providers/bigcommerce/2025-04/store.modifier.updated.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "275"
+  },
+  "body": {
+    "scope": "store/modifier/updated",
+    "store_id": "1025646",
+    "data": {
+      "type": "shared_modifier",
+      "id": 205,
+      "affected_product_ids": [
+        1,
+        2
+      ],
+      "context": {
+        "channel_id": 2,
+        "locale": "fr"
+      }
+    },
+    "hash": "a833a57fadd56a32dc752fb6ca0841dc9602a495",
+    "created_at": 1561479233,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/modifier/updated"
+}

--- a/providers/bigcommerce/2025-04/store.option.updated.json
+++ b/providers/bigcommerce/2025-04/store.option.updated.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "270"
+  },
+  "body": {
+    "scope": "store/option/updated",
+    "store_id": "1025646",
+    "data": {
+      "type": "local_option",
+      "id": 205,
+      "affected_product_ids": [
+        1,
+        2
+      ],
+      "context": {
+        "channel_id": 2,
+        "locale": "fr"
+      }
+    },
+    "hash": "a833a57fadd56a32dc752fb6ca0841dc9602a495",
+    "created_at": 1561479233,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/option/updated"
+}

--- a/providers/bigcommerce/2025-04/store.order.created.json
+++ b/providers/bigcommerce/2025-04/store.order.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "192"
+  },
+  "body": {
+    "scope": "store/order/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "order",
+      "id": 250
+    },
+    "hash": "dd70c0976e06b67aaf671e73f49dcb79230ebf9d",
+    "created_at": 1561479335,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/order/created"
+}

--- a/providers/bigcommerce/2025-04/store.order.message.created.json
+++ b/providers/bigcommerce/2025-04/store.order.message.created.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "233"
+  },
+  "body": {
+    "scope": "store/order/message/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "order",
+      "id": 250,
+      "message": {
+        "order_message_id": 3
+      }
+    },
+    "hash": "cb07cdbdda8b1965e812693d5988154807eeed02",
+    "created_at": 1561479923,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/order/message/created"
+}

--- a/providers/bigcommerce/2025-04/store.order.metafield.created.json
+++ b/providers/bigcommerce/2025-04/store.order.metafield.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "219"
+  },
+  "body": {
+    "scope": "store/order/metafield/created",
+    "store_id": "1001197568",
+    "data": {
+      "metafield_id": 14,
+      "resource_id": "270"
+    },
+    "hash": "8fd18449531d7e531587782eb200950cbad8cffe",
+    "created_at": 1683315012,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/order/metafield/created"
+}

--- a/providers/bigcommerce/2025-04/store.order.refund.created.json
+++ b/providers/bigcommerce/2025-04/store.order.refund.created.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "224"
+  },
+  "body": {
+    "scope": "store/order/refund/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "order",
+      "id": 250,
+      "refund": {
+        "refund_id": 3
+      }
+    },
+    "hash": "cb07cdbdda8b1965e812693d5988154807eeed02",
+    "created_at": 1561479923,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/order/refund/created"
+}

--- a/providers/bigcommerce/2025-04/store.order.statusUpdated.json
+++ b/providers/bigcommerce/2025-04/store.order.statusUpdated.json
@@ -1,0 +1,28 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "251"
+  },
+  "body": {
+    "scope": "store/order/statusUpdated",
+    "store_id": "1025646",
+    "data": {
+      "type": "order",
+      "id": 250,
+      "status": {
+        "previous_status_id": 0,
+        "new_status_id": 11
+      }
+    },
+    "hash": "7ee67cd1cf2ca60bc1aa9e5fe957d2de373be4ca",
+    "created_at": 1561479335,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/order/statusUpdated"
+}

--- a/providers/bigcommerce/2025-04/store.order.transaction.created.json
+++ b/providers/bigcommerce/2025-04/store.order.transaction.created.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "456"
+  },
+  "body": {
+    "scope": "store/order/transaction/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "transaction",
+      "order_id": 250,
+      "transaction_id": "176342342",
+      "transaction_status": "complete",
+      "transaction_type": "capture",
+      "result": {
+        "code": "captured",
+        "message": "Captured",
+        "type": "success"
+      },
+      "platform_transaction_id": "964899682",
+      "provider_transaction_id": "CK65FBPKR472P4V5"
+    },
+    "hash": "dd70c0976e06b67aaf671e73f49dcb79230ebf9d",
+    "created_at": 1561479335,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/order/transaction/created"
+}

--- a/providers/bigcommerce/2025-04/store.priceList.assignment.updated.json
+++ b/providers/bigcommerce/2025-04/store.priceList.assignment.updated.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "229"
+  },
+  "body": {
+    "store_id": "11111",
+    "producer": "stores/abcde",
+    "created_at": 1641641646,
+    "scope": "store/priceList/assignment/updated",
+    "data": {
+      "price_list_id": 2,
+      "channel_id": 1,
+      "customer_group_id": 3
+    },
+    "hash": "3f9ea420af83450d7ef9f78b08c8af25b2213637"
+  },
+  "topic": "store/priceList/assignment/updated"
+}

--- a/providers/bigcommerce/2025-04/store.priceList.created.json
+++ b/providers/bigcommerce/2025-04/store.priceList.created.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "193"
+  },
+  "body": {
+    "scope": "store/priceList/created",
+    "store_id": "1001197568",
+    "data": {
+      "price_list_id": 5
+    },
+    "hash": "e0c298b8097a6a2f39d17e593a9b360f5b2fef7d",
+    "created_at": 1709327895,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/priceList/created"
+}

--- a/providers/bigcommerce/2025-04/store.priceList.record.created.json
+++ b/providers/bigcommerce/2025-04/store.priceList.record.created.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "234"
+  },
+  "body": {
+    "scope": "store/priceList/record/created",
+    "store_id": "1001197568",
+    "data": {
+      "price_list_id": 1,
+      "variant_id": 179,
+      "currency": "USD"
+    },
+    "hash": "0424a15f158bbfe7277c5f84f9c55a1d4a762e60",
+    "created_at": 1709327895,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/priceList/record/created"
+}

--- a/providers/bigcommerce/2025-04/store.priceLists.deleted.json
+++ b/providers/bigcommerce/2025-04/store.priceLists.deleted.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "197"
+  },
+  "body": {
+    "scope": "store/priceLists/deleted",
+    "store_id": "1001197568",
+    "data": {
+      "price_list_ids": [
+        5
+      ]
+    },
+    "hash": "e0c298b8097a6a2f39d17e593a9b360f5b2fef7d",
+    "created_at": 1709327895,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/priceLists/deleted"
+}

--- a/providers/bigcommerce/2025-04/store.product.inventory.updated.json
+++ b/providers/bigcommerce/2025-04/store.product.inventory.updated.json
@@ -1,0 +1,29 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "275"
+  },
+  "body": {
+    "scope": "store/product/inventory/updated",
+    "store_id": "1025646",
+    "data": {
+      "type": "product",
+      "id": 167,
+      "inventory": {
+        "product_id": 167,
+        "method": "absolute",
+        "value": 100000000
+      }
+    },
+    "hash": "cba9eef399fbd6d384489bca6cacad24794b1086",
+    "created_at": 1561478843,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/product/inventory/updated"
+}

--- a/providers/bigcommerce/2025-04/store.product.updated.json
+++ b/providers/bigcommerce/2025-04/store.product.updated.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "293"
+  },
+  "body": {
+    "scope": "store/product/updated",
+    "store_id": "1025646",
+    "data": {
+      "type": "product",
+      "id": 205,
+      "properties": [
+        "warranty",
+        "is_featured",
+        "custom_fields"
+      ],
+      "context": {
+        "channel_id": 2,
+        "locale": "fr"
+      }
+    },
+    "hash": "a833a57fadd56a32dc752fb6ca0841dc9602a495",
+    "created_at": 1561479233,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/product/updated"
+}

--- a/providers/bigcommerce/2025-04/store.shipment.created.json
+++ b/providers/bigcommerce/2025-04/store.shipment.created.json
@@ -1,0 +1,25 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "211"
+  },
+  "body": {
+    "scope": "store/shipment/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "shipment",
+      "id": 12,
+      "orderId": 251
+    },
+    "hash": "8b98021cb0faa7e3a58a0e4182d3696a4bdd24ab",
+    "created_at": 1561482857,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/shipment/created"
+}

--- a/providers/bigcommerce/2025-04/store.sku.created.json
+++ b/providers/bigcommerce/2025-04/store.sku.created.json
@@ -1,0 +1,28 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "230"
+  },
+  "body": {
+    "scope": "store/sku/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "sku",
+      "id": 461,
+      "sku": {
+        "product_id": 206,
+        "variant_id": 509
+      }
+    },
+    "hash": "7a0866943b1f46cfda31c3218931f5aab83a4c73",
+    "created_at": 1561480465,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/sku/created"
+}

--- a/providers/bigcommerce/2025-04/store.sku.inventory.updated.json
+++ b/providers/bigcommerce/2025-04/store.sku.inventory.updated.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "276"
+  },
+  "body": {
+    "scope": "store/sku/inventory/updated",
+    "store_id": "1025646",
+    "data": {
+      "type": "sku",
+      "id": 461,
+      "inventory": {
+        "product_id": 206,
+        "method": "absolute",
+        "value": 5,
+        "variant_id": 509
+      }
+    },
+    "hash": "116ddb29d7bc1b2322cc1a4dc295221ee3637d4b",
+    "created_at": 1561480673,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/sku/inventory/updated"
+}

--- a/providers/bigcommerce/2025-04/store.subscriber.created.json
+++ b/providers/bigcommerce/2025-04/store.subscriber.created.json
@@ -1,0 +1,24 @@
+{
+  "headers": {
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "accept": "*/*",
+    "accept-language": "*",
+    "sec-fetch-mode": "cors",
+    "user-agent": "node",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "200"
+  },
+  "body": {
+    "scope": "store/subscriber/created",
+    "store_id": "1025646",
+    "data": {
+      "type": "subscriber",
+      "id": 5
+    },
+    "hash": "bdb6c9c2d17ca7036538e483db0bdd7debc4beb4",
+    "created_at": 1561482953,
+    "producer": "stores/{store_hash}"
+  },
+  "topic": "store/subscriber/created"
+}

--- a/providers/bigcommerce/index.json
+++ b/providers/bigcommerce/index.json
@@ -1,7 +1,7 @@
 {
     "label": "BigCommerce",
     "configs": {
-      "latest_version": "current",
+      "latest_version": "2025-04",
       "topic_identifier": "scope"
     }
   }

--- a/scripts/bigcommerce/.prettierrc
+++ b/scripts/bigcommerce/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/scripts/bigcommerce/README.md
+++ b/scripts/bigcommerce/README.md
@@ -1,0 +1,17 @@
+# Big Commerce Example Generation for console.hookdeck.com
+
+Script to read the contents of Big Commerce events reference pages and generate examples for [Hookdeck Console](https://console.hookdeck.com).
+
+## Usage
+
+Start the receiver in the top level of the repo:
+
+```sh
+yarn dev:receiver
+```
+
+Run the script to parse the Big Commerce reference pages and make `POST` requests to the receiver to capture the events.
+
+```sh
+yarn start
+```

--- a/scripts/bigcommerce/get-events.ts
+++ b/scripts/bigcommerce/get-events.ts
@@ -1,0 +1,108 @@
+import * as cheerio from "cheerio";
+
+interface BigCommerceEvent {
+  scope: string;
+  store_id: string;
+  data: any;
+}
+
+async function getScopedEvents(
+  url: string
+): Promise<Record<string, BigCommerceEvent>> {
+  console.log(`Fetching events from: ${url}`);
+  // Fetch the webpage content
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+
+  const html = await response.text();
+
+  // Load the HTML into cheerio
+  const $ = cheerio.load(html);
+
+  // Find all pre elements
+  const preElements = $("pre");
+
+  // Extract and log the content of each pre element
+  const eventExamples: BigCommerceEvent[] = [];
+  preElements.each((index: number, element: cheerio.Element) => {
+    const text = $(element).text();
+    const strippedText = text
+      .split("\n")
+      .map((line) => line.replace(/\/\/.*$/, "").trimEnd())
+      .join("\n");
+    try {
+      const event: BigCommerceEvent = JSON.parse(strippedText);
+      eventExamples.push(event);
+    } catch (error) {
+      console.error(`Error parsing JSON at element ${index + 1}:`, error);
+    }
+  });
+
+  console.log(`Total pre elements found: ${eventExamples.length}`);
+
+  // Extract unique scope values
+  const scopeToExampleMap: Record<string, any> = {};
+  eventExamples.forEach((event) => {
+    if (event.scope && !scopeToExampleMap[event.scope]) {
+      scopeToExampleMap[event.scope] = event;
+    }
+  });
+
+  return scopeToExampleMap;
+}
+
+async function getAllScopes(): Promise<void> {
+  const urls = [
+    "https://developer.bigcommerce.com/docs/integrations/webhooks/events",
+    "https://developer.bigcommerce.com/docs/integrations/webhooks/events/channels",
+    "https://developer.bigcommerce.com/docs/integrations/webhooks/events/inventory-location",
+  ];
+
+  const allScopesSet: Record<string, BigCommerceEvent> = {};
+
+  // Process each URL and collect unique scopes
+  for (const url of urls) {
+    const events = await getScopedEvents(url);
+    Object.values(events).forEach(
+      (event) => (allScopesSet[event.scope] = event)
+    );
+  }
+
+  const today = new Date().toISOString().split("T")[0].slice(0, 7); // Format: YYYY-MM
+
+  console.log(`Found ${Object.keys(allScopesSet).length} unique scopes`);
+
+  // Make a POST request for each scope
+  for (const [scope, event] of Object.entries(allScopesSet)) {
+    try {
+      const response = await fetch(
+        `http://localhost:9001/bigcommerce/${today}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(event),
+        }
+      );
+
+      if (!response.ok) {
+        console.error(
+          `Error posting scope ${scope}: ${response.status} ${response.statusText}`
+        );
+      } else {
+        console.log(`Successfully posted scope: ${scope}`);
+      }
+    } catch (error) {
+      console.error(`Failed to post scope ${scope}:`, error);
+    }
+  }
+
+  console.log("All scopes posted to server");
+}
+
+// Execute the function to get all scopes from all URLs
+getAllScopes();

--- a/scripts/bigcommerce/package-lock.json
+++ b/scripts/bigcommerce/package-lock.json
@@ -1,0 +1,1063 @@
+{
+  "name": "big-commerce-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "big-commerce-scripts",
+      "version": "1.0.0",
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.12",
+        "node-fetch": "^3.3.1"
+      },
+      "devDependencies": {
+        "@types/cheerio": "^0.22.31",
+        "@types/node": "^18.15.0",
+        "esrun": "^3.2.26",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@digitak/grubber": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@digitak/grubber/-/grubber-3.1.4.tgz",
+      "integrity": "sha512-pqsnp2BUYlDoTXWG34HWgEJse/Eo1okRgNex8IG84wHrJp8h3SakeR5WhB4VxSA2+/D+frNYJ0ch3yXzsfNDoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.35",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
+      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/esrun": {
+      "version": "3.2.26",
+      "resolved": "https://registry.npmjs.org/esrun/-/esrun-3.2.26.tgz",
+      "integrity": "sha512-gDjP87qj4RW0BryZXPY3/L161hPo9uG6luBTjLsuHG3cKnhSMrzB7eNzSzvDyBLg7OgugyvzSgB2ov7mZ/oa7Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@digitak/grubber": "^3.1.4",
+        "chokidar": "^3.5.1",
+        "esbuild": "^0.17.4"
+      },
+      "bin": {
+        "esrun": "bin.js"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/bigcommerce/package.json
+++ b/scripts/bigcommerce/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "big-commerce-scripts",
+  "version": "1.0.0",
+  "description": "Scripts for BigCommerce webhook management",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "esrun get-events.ts"
+  },
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.12",
+    "node-fetch": "^3.3.1"
+  },
+  "devDependencies": {
+    "esrun": "^3.2.26",
+    "@types/cheerio": "^0.22.31",
+    "@types/node": "^18.15.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/scripts/bigcommerce/tsconfig.json
+++ b/scripts/bigcommerce/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
Adds a script to parse event types from the Big Commerce docs. Then triggers the events to the receiving server so they can be captured.