### PR TITLE
Fix stale doc_sourced reference and enforce provenance consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ captured sample never has:
 }
 ```
 
-A provider whose samples are *all* doc-sourced also carries `doc_sourced: true`
-in its `index.json`.
+The version those samples live under is marked `"sourced_via": "docs"` in the
+provider's `provenance` block, so a consumer can tell without downloading the
+version file. The two must agree: a version marked `capture` may not contain
+files carrying a `source` key, and `yarn compile` fails the build if it does.
 
 Two things follow from the marking:
 

--- a/compile.ts
+++ b/compile.ts
@@ -65,6 +65,21 @@ const compile = async () => {
         );
 
         const parsed_topic = JSON.parse(topic_data);
+
+        // Two records of provenance have to agree: the per-file `source` key
+        // that doc-sourced samples carry, and the version-level block. A
+        // captured version containing a doc-sourced file means one of them is
+        // lying, and the version-level claim is the stronger one — it's what
+        // consumers filter on without downloading the samples.
+        if (
+          parsed_topic.source &&
+          config.provenance?.[version]?.sourced_via === "capture"
+        ) {
+          throw new Error(
+            `${provider}/${version} is marked sourced_via "capture" but ${topic} carries a "source" key, which only doc-sourced samples have`
+          );
+        }
+
         data[provider].versions[version][parsed_topic.topic] = parsed_topic;
         await fs.mkdir(path.join(__dirname, "public", "providers", provider), {
           recursive: true,


### PR DESCRIPTION
Two small follow-ups after #26 and #25 merged.

## The README still referenced `doc_sourced`

It told contributors that a provider whose samples are all doc-sourced carries `doc_sourced: true` in its `index.json`. Nothing has done that since provenance replaced the flag — no `index.json` sets it, and no code reads it. Replaced with what actually marks those versions:

```json
"provenance": {
  "latest": { "sourced_via": "docs", "sourced_on": "2026-07-29" }
}
```

## The two provenance records could drift

After both PRs, the same fact is recorded twice: the per-file `source` key that doc-sourced samples carry (1,260 files), and the version-level `provenance` block (95 providers). They're complementary rather than redundant — per-file travels with the payload and records exactly where each example was read, version-level is what a consumer can filter on without downloading every version file — but nothing kept them in step.

`compile.ts` now fails the build when a version marked `capture` contains a file with a `source` key:

```
Error: scrapfly/latest is marked sourced_via "capture" but crawler_started.json
carries a "source" key, which only doc-sourced samples have
```

That's the drift worth catching: doc-sourced samples published under a claim they were captured live. The reverse isn't checked — a `docs` version legitimately needn't mark every file.

## Testing

`yarn compile` passes on the full tree: 112 providers, 1,260 doc-sourced files, publishing `docs: 93, unknown: 21, capture: 2`. Planting a `source` key into a captured version fails as intended, and removing it passes again.

## One thing worth a second opinion

This is stricter than the tree it validates, so it's a new way for a build to break. If someone captures fresh samples over a version that was previously `docs` and flips `sourced_via` to `capture` without clearing the old `source` keys, compile stops rather than warns. That's deliberate — publishing a doc example as captured is the failure mode the whole provenance idea exists to prevent — but @garethx it's your `samples-doc/` workflow it would interrupt most, so say if you'd rather it warned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pce9oHWGjdwHsJNya1ovP